### PR TITLE
CI/BUG: Install `twine`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install Dependencies
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade pip setuptools wheel twine
 
       - name: Build sdist
         run: |


### PR DESCRIPTION
Small patch to #13

https://github.com/Flow-Launcher/Flow.Launcher.JsonRPC.Python/actions/runs/3289400758/jobs/5420880977#step:5:92

Twine is used to check the released packages.